### PR TITLE
EE 20468 Fix Enquiry Form Error Message Content

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ pipeline:
     - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     when:
-      brancj: master
+      branch: master
       event: push
 
   tag-docker-image-with-git-tag:

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ pipeline:
     - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: master
+      branch: [master, EE-20468]
       event: push
 
   tag-docker-image-with-git-tag:

--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ pipeline:
     - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-20468]
+      branch: master
       event: push
 
   tag-docker-image-with-git-tag:

--- a/html/418-request-denied.shtml
+++ b/html/418-request-denied.shtml
@@ -1,0 +1,8 @@
+<!--#if expr="$verbose_error_pages = TRUE" -->
+  <!--#set var="title" value="Request denied" -->
+  <!--#set var="partial" value="418-request-denied" -->
+<!--#else -->
+  <!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+  <!--#set var="partial" value="50x" -->
+<!--#endif -->
+<!--#include file="template.shtml" -->

--- a/html/500.shtml
+++ b/html/500.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+<!--#set var="partial" value="500" -->
+<!--#include file="template.shtml" -->

--- a/html/501.shtml
+++ b/html/501.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+<!--#set var="partial" value="501" -->
+<!--#include file="template.shtml" -->

--- a/html/502.shtml
+++ b/html/502.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+<!--#set var="partial" value="502" -->
+<!--#include file="template.shtml" -->

--- a/html/503.shtml
+++ b/html/503.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+<!--#set var="partial" value="503" -->
+<!--#include file="template.shtml" -->

--- a/html/504.shtml
+++ b/html/504.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, there is a problem with the enquiry form" -->
+<!--#set var="partial" value="504" -->
+<!--#include file="template.shtml" -->

--- a/html/50x.shtml
+++ b/html/50x.shtml
@@ -1,0 +1,3 @@
+<!--#set var="title" value="Sorry, it's completely bust" -->
+<!--#set var="partial" value="50x" -->
+<!--#include file="template.shtml" -->

--- a/html/partials/50x.shtml
+++ b/html/partials/50x.shtml
@@ -1,4 +1,3 @@
-<h1>There is a problem with the enquiry form</h1>
 <p>Try again later.</p>
 <p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone.</p>
 <p>Telephone:</p>

--- a/html/partials/50x.shtml
+++ b/html/partials/50x.shtml
@@ -1,4 +1,3 @@
-<h1>Sorry, there is a problem with the enquiry form</h1>
 <p>Try again later.</p>
 <p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone.</p>
 <p>Telephone:</p>

--- a/html/partials/50x.shtml
+++ b/html/partials/50x.shtml
@@ -1,9 +1,10 @@
 <p>Try again later.</p>
-<p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone.</p>
+<p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone:</p>
 <p>Telephone:</p>
 <p><strong>0300 123 7379</strong></p>
-<p>From outside the UK:</p>
-<p><strong>+44 203 080 0010</strong></p>
+<p>Outside the UK:</p>
+<p><strong>+44 (0)203 080 0010</strong></p>
 <p>Opening times:</p>
-<p><strong>08:00-20:00, Monday to Friday</strong></p>
-<p><strong>09:30-16:30, Saturday and Sunday</strong></p>
+<p><strong>Monday to Friday, excluding bank holidays: 8am to 8pm</strong></p>
+<p><strong>Saturday and Sunday: 9.30am to 4.30pm</strong></p>
+<div><a href="https://www.gov.uk/call-charges">Find out about call charges</a></div>

--- a/html/partials/50x.shtml
+++ b/html/partials/50x.shtml
@@ -1,4 +1,4 @@
-<h1>There is a problem with this service</h1>
+<h1>Sorry, there is a problem with the enquiry form</h1>
 <p>Try again later.</p>
 <p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone.</p>
 <p>Telephone:</p>

--- a/html/partials/50x.shtml
+++ b/html/partials/50x.shtml
@@ -1,3 +1,4 @@
+<h1>There is a problem with the enquiry form</h1>
 <p>Try again later.</p>
 <p>Your answers have not been saved and your question has not been sent. If the problem continues, please contact the EU Settlement Resolution Centre by telephone.</p>
 <p>Telephone:</p>


### PR DESCRIPTION
As per comments on EE-9144 I have updated the content of the error page to match Ref 8 of the table on https://confluence.ipttools.info/display/ES/Error+pages+for+service+problems

I have duplicated all the .shtml templates from docker-nginx-proxy-govuk and changed the title as this was the only way to get the title correct. I have verified manually that this change works.

I intend to push this to master once approved. This will create a new docker image for the proxy which will not currently be used anywhere. I will then raise another PR for kube-pttg-rps-enquiry-form to use the new image, to be tested before merging. 