### PR TITLE
Ee 27635 maintenance page

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,14 +9,44 @@ pipeline:
     when:
       event: [push, pull_request, tag]
 
-  install-docker-image:
-    image: docker:17.09.1
+  install-docker-image-with-githash-tag:
+    image: docker:18.03.1-ce
     environment:
     - DOCKER_HOST=tcp://172.17.0.1:2375
     secrets:
     - docker_password
     commands:
     - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+    - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:${DRONE_COMMIT_SHA:0:8}
+    - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:${DRONE_COMMIT_SHA:0:8}
+    when:
+      event: push
+
+  install-docker-image-from-feature-branch-build:
+    image: docker:18.03.1-ce
+    environment:
+    - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+    - docker_password
+    commands:
+    - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+    - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:${DRONE_BRANCH}
+    - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:${DRONE_BRANCH}
+    when:
+      branch:
+        exclude: master
+      event: push
+
+  install-docker-image-from-master-branch-build:
+    image: docker:18.03.1-ce
+    environment:
+    - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+    - docker_password
+    commands:
+    - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+    - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:latest
+    - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:latest
     - docker tag pttg-rps-enquiry-proxy quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry-proxy:build-$${DRONE_BUILD_NUMBER}
     when:

--- a/html/maintenance.html
+++ b/html/maintenance.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  Down for maintenance
+</body>
+</html>

--- a/html/maintenance.html
+++ b/html/maintenance.html
@@ -6,146 +6,128 @@
       (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
     </script>
     <!--[if gt IE 8]><!--><link href="/nginx-proxy/style/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
-    <!--[if IE 6]><link href="/nginx-proxy/style/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 7]><link href="/nginx-proxy/style/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if IE 8]><link href="/nginx-proxy/style/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
-    <link href="/nginx-proxy/style/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
-    <!--[if IE 8]>
-    <script type="text/javascript">
-      (function(){if(window.opera){return;}
-       setTimeout(function(){var a=document,g,b={families:(g=
-       ["nta"]),urls:["/nginx-proxy/style/fonts-ie8.css"]},
-       c="/nginx-proxy/scripts/vendor/goog/webfont-debug.js",d="script",
-       e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
-       ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
-       .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
-      })()
-    </script>
-    <![endif]-->
-    <!--[if gte IE 9]><!-->
+      <!--[if IE 6]><link href="/nginx-proxy/style/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+      <!--[if IE 7]><link href="/nginx-proxy/style/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+      <!--[if IE 8]><link href="/nginx-proxy/style/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+      <link href="/nginx-proxy/style/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+      <!--[if IE 8]>
+        <script type="text/javascript">
+          (function(){if(window.opera){return;}
+           setTimeout(function(){var a=document,g,b={families:(g=
+           ["nta"]),urls:["/nginx-proxy/style/fonts-ie8.css"]},
+           c="/nginx-proxy/scripts/vendor/goog/webfont-debug.js",d="script",
+           e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
+           ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
+           .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
+          })()
+        </script>
+      <![endif]-->
+      <!--[if gte IE 9]><!-->
       <link href="/nginx-proxy/style/fonts.css" media="all" rel="stylesheet" type="text/css" />
     <!--<![endif]-->
-    <!--[if lt IE 9]>
-      <script src="/nginx-proxy/scripts/ie.js" type="text/javascript"></script>
-    <![endif]-->
-    <link rel="shortcut icon" href="/nginx-proxy/images/favicon.ico" type="image/x-icon" />
-    <!-- Size for iPad and iPad mini (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/nginx-proxy/images/apple-touch-icon-152x152.png">
-    <!-- Size for iPhone and iPod touch (high resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/nginx-proxy/images/apple-touch-icon-120x120.png">
-    <!-- Size for iPad 2 and iPad mini (standard resolution) -->
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/nginx-proxy/images/apple-touch-icon-76x76.png">
-    <!-- Default non-defined size, also used for Android 2.1+ devices -->
-    <link rel="apple-touch-icon-precomposed" href="/nginx-proxy/images/apple-touch-icon-60x60.png">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="og:image" content="/nginx-proxy/images/opengraph-image.png">
-    <meta name="format-detection" content="telephone=no">
-    <link rel="stylesheet" href="/nginx-proxy/style/app.css">
-  </head>
-  <body class="">
-    <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-
-
-
-    <div id="skiplink-container">
-      <div>
-        <a href="#content" class="skiplink">Skip to main content</a>
-      </div>
-    </div>
-
-    <header role="banner" id="global-header" class="with-proposition">
-      <div class="header-wrapper">
-        <div class="header-global">
-          <div class="header-logo">
-            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
-              <img src="/nginx-proxy/images/gov.uk_logotype_crown.png" width="35" height="31" alt=""> GOV.UK
-            </a>
+        <!--[if lt IE 9]>
+          <script src="/nginx-proxy/scripts/ie.js" type="text/javascript"></script>
+        <![endif]-->
+        <link rel="shortcut icon" href="/nginx-proxy/images/favicon.ico" type="image/x-icon" />
+        <!-- Size for iPad and iPad mini (high resolution) -->
+        <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/nginx-proxy/images/apple-touch-icon-152x152.png">
+        <!-- Size for iPhone and iPod touch (high resolution) -->
+        <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/nginx-proxy/images/apple-touch-icon-120x120.png">
+        <!-- Size for iPad 2 and iPad mini (standard resolution) -->
+        <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/nginx-proxy/images/apple-touch-icon-76x76.png">
+        <!-- Default non-defined size, also used for Android 2.1+ devices -->
+        <link rel="apple-touch-icon-precomposed" href="/nginx-proxy/images/apple-touch-icon-60x60.png">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta property="og:image" content="/nginx-proxy/images/opengraph-image.png">
+        <meta name="format-detection" content="telephone=no">
+        <link rel="stylesheet" href="/nginx-proxy/style/app.css">
+      </head>
+      <body class="">
+        <script type="text/javascript">
+          document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+        </script>
+        <header role="banner" id="global-header" class="with-proposition">
+          <div class="header-wrapper">
+            <div class="header-global">
+              <div class="header-logo">
+                <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+                  <img src="/nginx-proxy/images/gov.uk_logotype_crown.png" width="35" height="31" alt=""> GOV.UK
+                </a>
+              </div>
+            </div>
+          </div>
+        </header>
+        <div id="global-header-bar">
+          <div class="inner-block">
+            <div class="header-bar"></div>
           </div>
         </div>
+        <main id="content" class="main" role="main">
+          <span id="step">
+            <span></span>
+          </span>
+          <div class="grid-row">
+            <div class="column-two-thirds">
+              <header>
+                <h1>Sorry, the enquiry form is undergoing maintenance</h1>
+              </header>
+              <div class="u-fr" style="float: right">
+                <ul class="c-language-nav">
+                  <li class="c-language-nav__item cy_errors hidden" >
+                    <a lang="en" hreflang="en" class="language-nav-link" href="#" onclick="showEnglishErrors()">English</a>
+                  </li>
+                  <li class="c-language-nav__item en_errors">
+                    <a lang="cy" hreflang="cy" class="language-nav-link" href="#" onclick="showWelshErrors()">Cymraeg</a>
+                  </li>
+                </ul>
+              </div>
+              <div class="en_errors"/>
+              <p>Please contact the EU Settlement Resolution Centre by telephone:</p>
+              <p>Telephone:</p>
+              <p><strong>0300 123 7379</strong></p>
+              <p>Outside the UK:</p>
+              <p><strong>+44 (0)203 080 0010</strong></p>
+              <p>Opening times:</p>
+              <p><strong>Monday to Friday, excluding bank holidays: 8am to 8pm</strong></p>
+              <p><strong>Saturday and Sunday: 9.30am to 4.30pm</strong></p>
+              <div><a href="https://www.gov.uk/call-charges">Find out about call charges</a></div>
+            </div>
+            <div class="cy_errors hidden"/>
+            <p>Cysylltwch â Chanolfan Datrys Setliadau’r UE dros y ffôn:</p>
+            <p>Ffôn:</p>
+            <p><strong>0300 123 7379</strong></p>
+            <p>Tu allan i’r DU:</p>
+            <p><strong>+44 (0)203 080 0010</strong></p>
+            <p>Oriau Agor:</p>
+            <p><strong>Dydd Llun i ddydd Gwener, ac eithrio gwyliau banc: 8am i 8pm</strong></p>
+            <p><strong>Dydd Sadwrn a dydd Sul: 9:30 am i 4.30pm</strong></p>
+            <div><a href="https://www.gov.uk/costau-galwadau">Darganfyddwch am daliadau galwadau</a></div>
+          </div>
+          <script>
+            function showWelshErrors() {
+                showElements(document.getElementsByClassName('cy_errors'));
+                hideElements(document.getElementsByClassName('en_errors'));
+            }
+            function showEnglishErrors() {
+                showElements(document.getElementsByClassName('en_errors'));
+                hideElements(document.getElementsByClassName('cy_errors'));
+            }
+            function hideElements(elements) {
+                for (let el = 0; el < elements.length; el++) {
+                    elements[el].classList.add('hidden');
+                }
+            }
+            function showElements(elements) {
+                for (let el = 0; el < elements.length; el++) {
+                    elements[el].classList.remove('hidden');
+                }
+            }
+          </script>
+        </div>
       </div>
-    </header>
-    <!--end header-->
-
-
-
-    <div id="global-header-bar">
-      <div class="inner-block">
-        <div class="header-bar"></div>
-      </div>
-    </div>
-    <!--end global-header-bar-->
-
-  <main id="content" class="main" role="main">
-    <span id="step">
-       <span></span>
-    </span>
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <header><h1>Sorry, the enquiry form is undergoing maintenance</h1></header>
-        <div class="u-fr" style="float: right">
-    <ul class="c-language-nav">
-        <li class="c-language-nav__item cy_errors hidden" >
-            <a lang="en" hreflang="en" class="language-nav-link" href="#" onclick="showEnglishErrors()">English</a>
-        </li>
-        <li class="c-language-nav__item en_errors">
-            <a lang="cy" hreflang="cy" class="language-nav-link" href="#" onclick="showWelshErrors()">Cymraeg</a>
-        </li>
-    </ul>
-</div>
-<div class="en_errors"/>
-    <p>Please contact the EU Settlement Resolution Centre by telephone:</p>
-    <p>Telephone:</p>
-    <p><strong>0300 123 7379</strong></p>
-    <p>Outside the UK:</p>
-    <p><strong>+44 (0)203 080 0010</strong></p>
-    <p>Opening times:</p>
-    <p><strong>Monday to Friday, excluding bank holidays: 8am to 8pm</strong></p>
-    <p><strong>Saturday and Sunday: 9.30am to 4.30pm</strong></p>
-    <div><a href="https://www.gov.uk/call-charges">Find out about call charges</a></div>
-</div>
-<div class="cy_errors hidden"/>
-    <p>Cysylltwch â Chanolfan Datrys Setliadau’r UE dros y ffôn:</p>
-    <p>Ffôn:</p>
-    <p><strong>0300 123 7379</strong></p>
-    <p>Tu allan i’r DU:</p>
-    <p><strong>+44 (0)203 080 0010</strong></p>
-    <p>Oriau Agor:</p>
-    <p><strong>Dydd Llun i ddydd Gwener, ac eithrio gwyliau banc: 8am i 8pm</strong></p>
-    <p><strong>Dydd Sadwrn a dydd Sul: 9:30 am i 4.30pm</strong></p>
-    <div><a href="https://www.gov.uk/costau-galwadau">Darganfyddwch am daliadau galwadau</a></div>
-</div>
-<script>
-    function showWelshErrors() {
-        showElements(document.getElementsByClassName('cy_errors'));
-        hideElements(document.getElementsByClassName('en_errors'));
-    }
-    function showEnglishErrors() {
-        showElements(document.getElementsByClassName('en_errors'));
-        hideElements(document.getElementsByClassName('cy_errors'));
-    }
-    function hideElements(elements) {
-        for (let el = 0; el < elements.length; el++) {
-            elements[el].classList.add('hidden');
-        }
-    }
-    function showElements(elements) {
-        for (let el = 0; el < elements.length; el++) {
-            elements[el].classList.remove('hidden');
-        }
-    }
-</script>
-
-        <a href="javascript: window.history.back()" title="Back" class="button">Back</a>
-        <a href="/" title="Start again" class="button">Start again</a>
-
-      </div>
-    </div>
-  </main>
-
+    </main>
     <footer class="group js-footer" id="footer" role="contentinfo">
-
       <div class="footer-wrapper">
-
         <div class="footer-meta">
           <div class="footer-meta-inner">
             <div class="open-government-licence">
@@ -153,7 +135,6 @@
               <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
             </div>
           </div>
-
           <div class="copyright">
             <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
           </div>

--- a/html/maintenance.html
+++ b/html/maintenance.html
@@ -1,5 +1,166 @@
 <html>
-<body>
-  Down for maintenance
-</body>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <title>Sorry, the enquiry form is undergoing maintenance – GOV.UK</title>
+    <script type="text/javascript">
+      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
+    </script>
+    <!--[if gt IE 8]><!--><link href="/nginx-proxy/style/govuk-template.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if IE 6]><link href="/nginx-proxy/style/govuk-template-ie6.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 7]><link href="/nginx-proxy/style/govuk-template-ie7.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <!--[if IE 8]><link href="/nginx-proxy/style/govuk-template-ie8.css" media="screen" rel="stylesheet" type="text/css" /><![endif]-->
+    <link href="/nginx-proxy/style/govuk-template-print.css" media="print" rel="stylesheet" type="text/css" />
+    <!--[if IE 8]>
+    <script type="text/javascript">
+      (function(){if(window.opera){return;}
+       setTimeout(function(){var a=document,g,b={families:(g=
+       ["nta"]),urls:["/nginx-proxy/style/fonts-ie8.css"]},
+       c="/nginx-proxy/scripts/vendor/goog/webfont-debug.js",d="script",
+       e=a.createElement(d),f=a.getElementsByTagName(d)[0],h=g.length;WebFontConfig
+       ={custom:b},e.src=c,f.parentNode.insertBefore(e,f);for(;h=h-1;a.documentElement
+       .className+=' wf-'+g[h].replace(/\s/g,'').toLowerCase()+'-n4-loading');},0)
+      })()
+    </script>
+    <![endif]-->
+    <!--[if gte IE 9]><!-->
+      <link href="/nginx-proxy/style/fonts.css" media="all" rel="stylesheet" type="text/css" />
+    <!--<![endif]-->
+    <!--[if lt IE 9]>
+      <script src="/nginx-proxy/scripts/ie.js" type="text/javascript"></script>
+    <![endif]-->
+    <link rel="shortcut icon" href="/nginx-proxy/images/favicon.ico" type="image/x-icon" />
+    <!-- Size for iPad and iPad mini (high resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/nginx-proxy/images/apple-touch-icon-152x152.png">
+    <!-- Size for iPhone and iPod touch (high resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/nginx-proxy/images/apple-touch-icon-120x120.png">
+    <!-- Size for iPad 2 and iPad mini (standard resolution) -->
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/nginx-proxy/images/apple-touch-icon-76x76.png">
+    <!-- Default non-defined size, also used for Android 2.1+ devices -->
+    <link rel="apple-touch-icon-precomposed" href="/nginx-proxy/images/apple-touch-icon-60x60.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:image" content="/nginx-proxy/images/opengraph-image.png">
+    <meta name="format-detection" content="telephone=no">
+    <link rel="stylesheet" href="/nginx-proxy/style/app.css">
+  </head>
+  <body class="">
+    <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">Skip to main content</a>
+      </div>
+    </div>
+
+    <header role="banner" id="global-header" class="with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+              <img src="/nginx-proxy/images/gov.uk_logotype_crown.png" width="35" height="31" alt=""> GOV.UK
+            </a>
+          </div>
+        </div>
+      </div>
+    </header>
+    <!--end header-->
+
+
+
+    <div id="global-header-bar">
+      <div class="inner-block">
+        <div class="header-bar"></div>
+      </div>
+    </div>
+    <!--end global-header-bar-->
+
+  <main id="content" class="main" role="main">
+    <span id="step">
+       <span></span>
+    </span>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <header><h1>Sorry, the enquiry form is undergoing maintenance</h1></header>
+        <div class="u-fr" style="float: right">
+    <ul class="c-language-nav">
+        <li class="c-language-nav__item cy_errors hidden" >
+            <a lang="en" hreflang="en" class="language-nav-link" href="#" onclick="showEnglishErrors()">English</a>
+        </li>
+        <li class="c-language-nav__item en_errors">
+            <a lang="cy" hreflang="cy" class="language-nav-link" href="#" onclick="showWelshErrors()">Cymraeg</a>
+        </li>
+    </ul>
+</div>
+<div class="en_errors"/>
+    <p>Please contact the EU Settlement Resolution Centre by telephone:</p>
+    <p>Telephone:</p>
+    <p><strong>0300 123 7379</strong></p>
+    <p>Outside the UK:</p>
+    <p><strong>+44 (0)203 080 0010</strong></p>
+    <p>Opening times:</p>
+    <p><strong>Monday to Friday, excluding bank holidays: 8am to 8pm</strong></p>
+    <p><strong>Saturday and Sunday: 9.30am to 4.30pm</strong></p>
+    <div><a href="https://www.gov.uk/call-charges">Find out about call charges</a></div>
+</div>
+<div class="cy_errors hidden"/>
+    <p>Cysylltwch â Chanolfan Datrys Setliadau’r UE dros y ffôn:</p>
+    <p>Ffôn:</p>
+    <p><strong>0300 123 7379</strong></p>
+    <p>Tu allan i’r DU:</p>
+    <p><strong>+44 (0)203 080 0010</strong></p>
+    <p>Oriau Agor:</p>
+    <p><strong>Dydd Llun i ddydd Gwener, ac eithrio gwyliau banc: 8am i 8pm</strong></p>
+    <p><strong>Dydd Sadwrn a dydd Sul: 9:30 am i 4.30pm</strong></p>
+    <div><a href="https://www.gov.uk/costau-galwadau">Darganfyddwch am daliadau galwadau</a></div>
+</div>
+<script>
+    function showWelshErrors() {
+        showElements(document.getElementsByClassName('cy_errors'));
+        hideElements(document.getElementsByClassName('en_errors'));
+    }
+    function showEnglishErrors() {
+        showElements(document.getElementsByClassName('en_errors'));
+        hideElements(document.getElementsByClassName('cy_errors'));
+    }
+    function hideElements(elements) {
+        for (let el = 0; el < elements.length; el++) {
+            elements[el].classList.add('hidden');
+        }
+    }
+    function showElements(elements) {
+        for (let el = 0; el < elements.length; el++) {
+            elements[el].classList.remove('hidden');
+        }
+    }
+</script>
+
+        <a href="javascript: window.history.back()" title="Back" class="button">Back</a>
+        <a href="/" title="Start again" class="button">Start again</a>
+
+      </div>
+    </div>
+  </main>
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+              <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!--end footer-->
+    <div id="global-app-error" class="app-error hidden"></div>
+  </body>
 </html>


### PR DESCRIPTION
Adding a static page to be served up when the Enquiry Form is 'down for maintenance'. I have basically copied the rendered HTML from the error page and tweaked it slightly. Content is to be sorted out as another ticket, EE-27736, this is just to set up the technical detail.

I've also made it so that feature branches push to Quay like with other projects.

I will put this PR on the Jira to test. There's other work to be done in the kube-projects in order to make this work.